### PR TITLE
Need to require StringIO

### DIFF
--- a/lib/benchmark/memory/job/io_output/entry_formatter.rb
+++ b/lib/benchmark/memory/job/io_output/entry_formatter.rb
@@ -1,3 +1,4 @@
+require "stringio"
 require "benchmark/memory/helpers"
 require "benchmark/memory/job/io_output/metric_formatter"
 


### PR DESCRIPTION
This fixes

```
benchmark-memory-0.1.1/lib/benchmark/memory/job/io_output/entry_formatter.rb:26:in `to_s': uninitialized constant Benchmark::Memory::Job::IOOutput::EntryFormatter::StringIO (NameError)
```