### PR TITLE
Update tested Ruby versions and Code Climate usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,23 @@
 cache: bundler
 language: ruby
 rvm:
-  - 2.1.9
-  - 2.2.5
-  - 2.3.1
+  - 2.1.10
+  - 2.2.6
+  - 2.3.3
   - ruby-head
 script: bundle exec rspec
 sudo: false
 
-before_install: gem install bundler -v 1.12.3
+before_install: gem install bundler -v 1.14.3
 bundler_args: --without development
 
 matrix:
   allow_failures:
     - rvm: ruby-head
+  include:
+    - rvm: 2.4.0
+      after_script:
+        - bundle exec codeclimate-test-reporter
 
 addons:
   code_climate:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,5 @@
-require "codeclimate-test-reporter"
-CodeClimate::TestReporter.start
-
 if ENV["COVERAGE"] || ENV["CI"]
   require "simplecov"
-
-  SimpleCov.formatters = [SimpleCov::Formatter::HTMLFormatter]
 
   SimpleCov.start do
     add_filter "/spec/"


### PR DESCRIPTION
Code Climate's gem behavior changed, so we need to update to the new
expected behavior.

Also, bumped the versions of Ruby that we are testing on to the most
recent release of supported versions.