### PR TITLE
Drop support for Ruby 2.3, upgrade rubocop.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,13 +1,8 @@
 AllCops:
-  Include:
-    - "Gemfile"
-    - "Guardfile"
-    - "Rakefile"
-    - "*.gemspec"
   Exclude:
     - "vendor/**/*"
     - "db/schema.rb"
-  TargetRubyVersion: 2.1
+  TargetRubyVersion: 2.4
 
 Naming/FileName:
   Description: Use snake_case for source file names.
@@ -23,3 +18,9 @@ Metrics/BlockLength:
 Metrics/MethodLength:
   Exclude:
     - spec/**/*.rb
+
+# TODO: don't know how to fix, false positive?
+# https://github.com/rubocop-hq/rubocop/issues/5953
+Style/AccessModifierDeclarations:
+  Exclude:
+    - lib/benchmark/memory/helpers.rb

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ cache: bundler
 language: ruby
 
 rvm:
-  - 2.3
   - 2.4
   - 2.5
   - 2.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Added
 
+- [#11](https://github.com/michaelherold/benchmark-memory/pull/11): Drop support for Ruby < 2.4 - [@dblock](https://github.com/dblock).
 - Your contribution here.
 
 ## [0.1.2] - 2017-01-30

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gemspec
@@ -10,7 +12,7 @@ group :development do
   gem 'guard-rubocop'
   gem 'inch'
   gem 'rake', '>= 12.3.3'
-  gem 'rubocop', '0.52.1'
+  gem 'rubocop', '0.91.0'
   gem 'yard', '~> 0.9.11'
 
   group :test do

--- a/Guardfile
+++ b/Guardfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 guard :bundler do
   watch('Gemfile')
   watch('interactor-contracts.gemspec')

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler'
 Bundler.setup
 Bundler::GemHelper.install_tasks

--- a/benchmark-memory.gemspec
+++ b/benchmark-memory.gemspec
@@ -1,4 +1,6 @@
-require File.expand_path('../lib/benchmark/memory/version', __FILE__)
+# frozen_string_literal: true
+
+require File.expand_path('lib/benchmark/memory/version', __dir__)
 
 Gem::Specification.new do |spec|
   spec.name          = 'benchmark-memory'
@@ -6,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Michael Herold']
   spec.email         = ['michael.j.herold@gmail.com']
 
-  spec.summary       = 'Benchmark-style memory profiling for Ruby 2.1+'
+  spec.summary       = 'Benchmark-style memory profiling.'
   spec.description   = spec.summary
   spec.homepage      = 'https://github.com/michaelherold/benchmark-memory'
   spec.license       = 'MIT'
@@ -16,5 +18,6 @@ Gem::Specification.new do |spec|
   spec.files += Dir['lib/**/*.rb']
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 2.4'
   spec.add_dependency 'memory_profiler', '~> 0.9'
 end

--- a/bin/console
+++ b/bin/console
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'bundler/setup'
 require 'benchmark/memory'

--- a/lib/benchmark-memory.rb
+++ b/lib/benchmark-memory.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require 'benchmark/memory'

--- a/lib/benchmark/memory.rb
+++ b/lib/benchmark/memory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'benchmark/memory/errors'
 require 'benchmark/memory/job'
 require 'benchmark/memory/version'

--- a/lib/benchmark/memory/errors.rb
+++ b/lib/benchmark/memory/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Benchmark
   module Memory
     Error = Class.new(StandardError)

--- a/lib/benchmark/memory/held_results.rb
+++ b/lib/benchmark/memory/held_results.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'forwardable'
 require 'benchmark/memory/held_results/entry_serializer'
 
@@ -43,7 +45,7 @@ module Benchmark
         if @path.is_a?(String)
           File.exist?(@path)
         else
-          @path.size > 0 # rubocop:disable Style/ZeroLengthPredicate
+          @path.size.positive?
         end
       end
 
@@ -58,7 +60,7 @@ module Benchmark
       #
       # @return [Boolean]
       def holding?
-        !!@path # rubocop:disable Style/DoubleNegation
+        !!@path
       end
 
       # Check whether an entry has been added to the results.

--- a/lib/benchmark/memory/held_results/entry_serializer.rb
+++ b/lib/benchmark/memory/held_results/entry_serializer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'benchmark/memory/held_results/serializer'
 require 'benchmark/memory/held_results/measurement_serializer'
 require 'benchmark/memory/report/entry'

--- a/lib/benchmark/memory/held_results/measurement_serializer.rb
+++ b/lib/benchmark/memory/held_results/measurement_serializer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'benchmark/memory/held_results/serializer'
 require 'benchmark/memory/held_results/metric_serializer'
 require 'benchmark/memory/measurement'

--- a/lib/benchmark/memory/held_results/metric_serializer.rb
+++ b/lib/benchmark/memory/held_results/metric_serializer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'benchmark/memory/held_results/serializer'
 require 'benchmark/memory/measurement/metric'
 

--- a/lib/benchmark/memory/held_results/serializer.rb
+++ b/lib/benchmark/memory/held_results/serializer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 
 module Benchmark
@@ -54,7 +56,7 @@ module Benchmark
         # Convert the object to a JSON document.
         #
         # @return [String] The object as a JSON document.
-        def to_json
+        def to_json(*_args)
           JSON.generate(to_h)
         end
         alias to_s to_json

--- a/lib/benchmark/memory/helpers.rb
+++ b/lib/benchmark/memory/helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'benchmark/memory/human_readable_unit'
 
 module Benchmark
@@ -29,6 +31,7 @@ module Benchmark
 
         format("%10.3f#{value.unit}", value.to_f / (1000**value.scale))
       end
+
       module_function :scale
     end
   end

--- a/lib/benchmark/memory/human_readable_unit.rb
+++ b/lib/benchmark/memory/human_readable_unit.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'delegate'
 
 module Benchmark

--- a/lib/benchmark/memory/job.rb
+++ b/lib/benchmark/memory/job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'forwardable'
 require 'benchmark/memory/job/task'
 require 'benchmark/memory/job/io_output'
@@ -64,9 +66,7 @@ module Benchmark
       #
       # @raise [ArgumentError] if no code block is specified.
       def report(label = '', &block)
-        unless block_given?
-          raise ArgumentError, 'You did not specify a block for the item'
-        end
+        raise ArgumentError, 'You did not specify a block for the item' unless block_given?
 
         tasks.push Task.new(label, block)
       end

--- a/lib/benchmark/memory/job/io_output.rb
+++ b/lib/benchmark/memory/job/io_output.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'benchmark/memory/job/io_output/comparison_formatter'
 require 'benchmark/memory/job/io_output/entry_formatter'
 

--- a/lib/benchmark/memory/job/io_output/comparison_formatter.rb
+++ b/lib/benchmark/memory/job/io_output/comparison_formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'benchmark/memory/helpers'
 require 'benchmark/memory/job/io_output/metric_formatter'
 
@@ -51,10 +53,10 @@ module Benchmark
           end
 
           def comparison_between(entry, best)
-            ratio = entry.allocated_memory.to_f / best.allocated_memory.to_f
+            ratio = entry.allocated_memory.to_f / best.allocated_memory
 
             if ratio.abs > 1
-              format('%.2fx more', ratio)
+              format('%<ratio>.2fx more', ratio: ratio)
             else
               'same'
             end

--- a/lib/benchmark/memory/job/io_output/entry_formatter.rb
+++ b/lib/benchmark/memory/job/io_output/entry_formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'stringio'
 require 'benchmark/memory/helpers'
 require 'benchmark/memory/job/io_output/metric_formatter'

--- a/lib/benchmark/memory/job/io_output/metric_formatter.rb
+++ b/lib/benchmark/memory/job/io_output/metric_formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'benchmark/memory/helpers'
 
 module Benchmark

--- a/lib/benchmark/memory/job/null_output.rb
+++ b/lib/benchmark/memory/job/null_output.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Benchmark
   module Memory
     class Job

--- a/lib/benchmark/memory/job/task.rb
+++ b/lib/benchmark/memory/job/task.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'memory_profiler'
 require 'benchmark/memory/measurement'
 

--- a/lib/benchmark/memory/measurement.rb
+++ b/lib/benchmark/memory/measurement.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'forwardable'
 require 'benchmark/memory/measurement/metric_extractor'
 

--- a/lib/benchmark/memory/measurement/metric.rb
+++ b/lib/benchmark/memory/measurement/metric.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'benchmark/memory/helpers'
 
 module Benchmark

--- a/lib/benchmark/memory/measurement/metric_extractor.rb
+++ b/lib/benchmark/memory/measurement/metric_extractor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'benchmark/memory/measurement/metric'
 
 module Benchmark

--- a/lib/benchmark/memory/report.rb
+++ b/lib/benchmark/memory/report.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'benchmark/memory/report/comparison'
 require 'benchmark/memory/report/entry'
 

--- a/lib/benchmark/memory/report/comparison.rb
+++ b/lib/benchmark/memory/report/comparison.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Benchmark
   module Memory
     class Report

--- a/lib/benchmark/memory/report/entry.rb
+++ b/lib/benchmark/memory/report/entry.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'forwardable'
 
 module Benchmark

--- a/lib/benchmark/memory/version.rb
+++ b/lib/benchmark/memory/version.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module Benchmark
   module Memory
-    VERSION = '0.1.2'.freeze
+    VERSION = '0.1.2'
   end
 end

--- a/spec/benchmark/memory/held_results/entry_serializer_spec.rb
+++ b/spec/benchmark/memory/held_results/entry_serializer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Benchmark::Memory::HeldResults::EntrySerializer do

--- a/spec/benchmark/memory/helpers_spec.rb
+++ b/spec/benchmark/memory/helpers_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Benchmark::Memory::Helpers do

--- a/spec/benchmark/memory/job/io_output/comparison_formatter_spec.rb
+++ b/spec/benchmark/memory/job/io_output/comparison_formatter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Benchmark::Memory::Job::IOOutput::ComparisonFormatter do

--- a/spec/benchmark/memory/job/io_output_spec.rb
+++ b/spec/benchmark/memory/job/io_output_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Benchmark::Memory::Job::IOOutput do

--- a/spec/benchmark/memory/job/task_spec.rb
+++ b/spec/benchmark/memory/job/task_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Benchmark::Memory::Job::Task do

--- a/spec/benchmark/memory/job_spec.rb
+++ b/spec/benchmark/memory/job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Benchmark::Memory::Job do

--- a/spec/benchmark/memory/measurement/metric_spec.rb
+++ b/spec/benchmark/memory/measurement/metric_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Benchmark::Memory::Measurement::Metric do

--- a/spec/benchmark/memory/report/comparison_spec.rb
+++ b/spec/benchmark/memory/report/comparison_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Benchmark::Memory::Report::Comparison do

--- a/spec/benchmark/memory/report_spec.rb
+++ b/spec/benchmark/memory/report_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Benchmark::Memory::Report do

--- a/spec/benchmark/memory_spec.rb
+++ b/spec/benchmark/memory_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Benchmark::Memory do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 if ENV['COVERAGE'] || ENV['CI']
   require 'simplecov'
 


### PR DESCRIPTION
On top of #10.

Officially dropped support for Ruby 2.3 and upgraded Rubocop (0.91.0 requires Ruby 2.4+), although code would still run on 2.3.