### PR TITLE
Update `memory_profiler` to 1.0

### DIFF
--- a/benchmark-memory.gemspec
+++ b/benchmark-memory.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |spec|
   spec.files += Dir['lib/**/*.rb']
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'memory_profiler', '~> 0.9'
+  spec.add_dependency 'memory_profiler', '~> 1.0'
 end


### PR DESCRIPTION
Changelog: https://github.com/SamSaffron/memory_profiler/blob/master/CHANGELOG.md#100---02-12-2020

Noticable: dropping support of old Ruby versions.