### PR TITLE
Added Support for Linux on Power

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ sudo: false
 cache: bundler
 
 language: ruby
-
+arch:
+  - amd64
+  - ppc64le
 rvm:
   - 2.4
   - 2.5


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.
https://travis-ci.com/github/ujjwalsh/benchmark-memory/builds/207319675
Please have a look.

Regards,
ujjwal
