### PR TITLE
Allow for sorting by different criteria

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,6 +63,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ matrix.ruby }}-
 
+      - name: Ensure proper Bundler installed
+        if: ${{ matrix.ruby == 2.5 || matrix.ruby == 2.6 }}
+        run: gem install bundler:2.2.28
+
       - name: Bundle install
         run: |
           bundle config --local path vendor/bundle

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /.bundle/
 /.yardoc
-/Gemfile.lock
 /_yardoc/
 /coverage/
 /doc/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file. This projec
 ### Added
 
 - [#11](https://github.com/michaelherold/benchmark-memory/pull/11): Drop support for Ruby < 2.4 - [@dblock](https://github.com/dblock).
+- [#23](https://github.com/michaelherold/benchmark-memory/pull/23): Allow for sorting the comparison by different criteria - [@michaelherold](https://github.com/michaelherold).
 - Your contribution here.
 
 ### Updated

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,129 @@
+PATH
+  remote: .
+  specs:
+    benchmark-memory (0.1.2)
+      memory_profiler (~> 1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.2)
+    coderay (1.1.3)
+    diff-lcs (1.4.4)
+    docile (1.3.5)
+    ffi (1.13.1)
+    formatador (0.2.5)
+    guard (2.16.2)
+      formatador (>= 0.2.4)
+      listen (>= 2.7, < 4.0)
+      lumberjack (>= 1.0.12, < 2.0)
+      nenv (~> 0.1)
+      notiffany (~> 0.0)
+      pry (>= 0.9.12)
+      shellany (~> 0.0)
+      thor (>= 0.18.1)
+    guard-bundler (3.0.0)
+      bundler (>= 2.1, < 3)
+      guard (~> 2.2)
+      guard-compat (~> 1.1)
+    guard-compat (1.2.1)
+    guard-inch (0.2.0)
+      guard (~> 2)
+      inch (~> 0)
+    guard-rspec (4.7.3)
+      guard (~> 2.1)
+      guard-compat (~> 1.1)
+      rspec (>= 2.99.0, < 4.0)
+    guard-rubocop (1.4.0)
+      guard (~> 2.0)
+      rubocop (< 2.0)
+    inch (0.8.0)
+      pry
+      sparkr (>= 0.2.0)
+      term-ansicolor
+      yard (~> 0.9.12)
+    listen (3.3.1)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    lumberjack (1.2.8)
+    memory_profiler (1.0.0)
+    method_source (1.0.0)
+    nenv (0.3.0)
+    notiffany (0.1.3)
+      nenv (~> 0.1)
+      shellany (~> 0.0)
+    parallel (1.20.1)
+    parser (3.0.0.0)
+      ast (~> 2.4.1)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    rainbow (3.0.0)
+    rake (13.0.1)
+    rb-fsevent (0.10.4)
+    rb-inotify (0.10.1)
+      ffi (~> 1.0)
+    regexp_parser (2.1.1)
+    rexml (3.2.4)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.0)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.0)
+    rubocop (1.11.0)
+      parallel (~> 1.10)
+      parser (>= 3.0.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.2.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.4.1)
+      parser (>= 2.7.1.5)
+    ruby-progressbar (1.11.0)
+    shellany (0.0.1)
+    simplecov (0.21.2)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.2)
+    sparkr (0.4.1)
+    sync (0.5.0)
+    term-ansicolor (1.7.1)
+      tins (~> 1.0)
+    thor (1.0.1)
+    tins (1.26.0)
+      sync
+    unicode-display_width (2.0.0)
+    yard (0.9.25)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  benchmark-memory!
+  guard
+  guard-bundler
+  guard-inch
+  guard-rspec (~> 4.6)
+  guard-rubocop
+  inch
+  pry
+  rake (>= 12.3.3)
+  rspec (~> 3.4)
+  rubocop (~> 1)
+  simplecov (> 0.20)
+  yard (~> 0.9.11)
+
+BUNDLED WITH
+   2.2.28

--- a/README.md
+++ b/README.md
@@ -97,6 +97,30 @@ end
 
 Calling `#compare!` on the job within the setup block of `Benchmark.memory` enables the output of the comparison section of the benchmark. Without it, the benchmark suppresses this section and you only get the raw numbers output during calculation.
 
+By default, this compares the reports by the amount of allocated memory. You can configure the comparison along two axes. The first axis is the metric, which is one of: `:memory`, `:objects`, or `:strings`. The second is the value, which is either `:allocated` or `:retained`.
+
+Depending on what you're trying to benchmark, different configurations make sense. For example:
+
+``` ruby
+Benchmark.memory do |bench|
+  bench.compare! memory: :allocated
+  # or, equivalently:
+  # bench.compare!
+end
+```
+
+The purpose of the default configuration is benchmarking the total amount of memory an algorithm might use. If you're trying to improve a memory-intensive task, this is the mode you want.
+
+An alternative comparison might look like:
+
+``` ruby
+Benchmark.memory do |bench|
+  bench.compare! memory: :retained
+end
+```
+
+When you're looking for a memory leak, this configuration can help you because it compares your reports by the amount of memory that the garbage collector does not collect after the benchmark.
+
 ### Hold results between invocations
 
 ```ruby

--- a/lib/benchmark/memory/job.rb
+++ b/lib/benchmark/memory/job.rb
@@ -6,6 +6,7 @@ require 'benchmark/memory/job/io_output'
 require 'benchmark/memory/job/null_output'
 require 'benchmark/memory/held_results'
 require 'benchmark/memory/report'
+require 'benchmark/memory/report/comparator'
 
 module Benchmark
   module Memory
@@ -20,7 +21,6 @@ module Benchmark
       #
       # @return [Job]
       def initialize(output: $stdout, quiet: false)
-        @compare = false
         @full_report = Report.new
         @held_results = HeldResults.new
         @quiet = quiet
@@ -40,14 +40,14 @@ module Benchmark
       #
       # @return [Boolean]
       def compare?
-        @compare
+        !!@comparator
       end
 
       # Enable output of a comparison of the different tasks.
       #
       # @return [void]
-      def compare!
-        @compare = true
+      def compare!(**spec)
+        @comparator = full_report.comparator = Report::Comparator.from_spec(spec.to_h)
       end
 
       # Enable holding results to compare between separate runs.

--- a/lib/benchmark/memory/job/io_output/comparison_formatter.rb
+++ b/lib/benchmark/memory/job/io_output/comparison_formatter.rb
@@ -43,17 +43,17 @@ module Benchmark
           private
 
           def add_best_summary(best, output)
-            output << summary_message("%20s: %10i allocated\n", best)
+            output << summary_message("%20s: %10i %s\n", best)
           end
 
           def add_comparison(entry, best, output)
-            output << summary_message('%20s: %10i allocated - ', entry)
+            output << summary_message('%20s: %10i %s - ', entry)
             output << comparison_between(entry, best)
             output << "\n"
           end
 
           def comparison_between(entry, best)
-            ratio = entry.allocated_memory.to_f / best.allocated_memory
+            ratio = entry.compared_metric(comparison).to_f / best.compared_metric(comparison)
 
             if ratio.abs > 1
               format('%<ratio>.2fx more', ratio: ratio)
@@ -63,7 +63,7 @@ module Benchmark
           end
 
           def summary_message(message, entry)
-            format(message, entry.label, entry.allocated_memory)
+            format(message, entry.label, entry.compared_metric(comparison), comparison.value)
           end
         end
       end

--- a/lib/benchmark/memory/measurement.rb
+++ b/lib/benchmark/memory/measurement.rb
@@ -7,7 +7,6 @@ module Benchmark
   module Memory
     # Encapsulate the combined metrics of an action.
     class Measurement
-      include Comparable
       include Enumerable
       extend Forwardable
 
@@ -49,22 +48,6 @@ module Benchmark
 
       # Enumerate through the metrics when enumerating a measurement.
       def_delegator :metrics, :each
-
-      # Compare two measurements for sorting purposes.
-      #
-      # @param other [Measurement] The other measurement
-      #
-      # @return [Integer]
-      def <=>(other)
-        memory <=> other.memory
-      end
-
-      # Total amount of allocated memory for the measurement.
-      #
-      # @return [Integer]
-      def allocated_memory
-        memory.allocated
-      end
     end
   end
 end

--- a/lib/benchmark/memory/measurement/metric.rb
+++ b/lib/benchmark/memory/measurement/metric.rb
@@ -7,8 +7,6 @@ module Benchmark
     class Measurement
       # Describe the ratio of allocated vs. retained memory in a measurement.
       class Metric
-        include Comparable
-
         # Instantiate a Metric of allocated vs. retained memory.
         #
         # @param type [Symbol] The type of memory allocated in the metric.
@@ -28,15 +26,6 @@ module Benchmark
 
         # @return [Symbol] The type of memory allocated in the metric.
         attr_reader :type
-
-        # Sort by the total allocated.
-        #
-        # @param other [Metric] The other metric.
-        #
-        # @return [Integer]
-        def <=>(other)
-          allocated <=> other.allocated
-        end
       end
     end
   end

--- a/lib/benchmark/memory/report.rb
+++ b/lib/benchmark/memory/report.rb
@@ -12,7 +12,11 @@ module Benchmark
       # @return [Report]
       def initialize
         @entries = []
+        @comparator = Comparator.new
       end
+
+      # @return [Comparator] The {Comparator} to use when creating the {Comparison}.
+      attr_accessor :comparator
 
       # @return [Array<Entry>] The entries in the report.
       attr_reader :entries
@@ -40,7 +44,7 @@ module Benchmark
       #
       # @return [Comparison]
       def comparison
-        @comparison ||= Comparison.new(entries)
+        @comparison ||= Comparison.new(entries, comparator)
       end
     end
   end

--- a/lib/benchmark/memory/report/comparator.rb
+++ b/lib/benchmark/memory/report/comparator.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module Benchmark
+  module Memory
+    class Report
+      # Compares two {Entry} for the purposes of sorting and outputting a {Comparison}.
+      class Comparator
+        # @private
+        METRICS = %i[memory objects strings].freeze
+
+        # @private
+        VALUES  = %i[allocated retained].freeze
+
+        # Instantiates a {Comparator} from a spec given by {Job#compare!}
+        #
+        # @param spec [Hash<Symbol, Symbol>] The specification given for the {Comparator}
+        # @return [Comparator]
+        def self.from_spec(spec)
+          raise ArgumentError, 'Only send a single metric and value, in the form memory: :allocated' if spec.length > 1
+
+          metric, value = *spec.first
+          metric ||= :memory
+          value  ||= :allocated
+
+          new(metric: metric, value: value)
+        end
+
+        # Instantiate a new comparator
+        #
+        # @param metric [Symbol] (see #metric)
+        # @param value [Symbol] (see #value)
+        def initialize(metric: :memory, value: :allocated)
+          raise ArgumentError, "Invalid metric: #{metric.inspect}" unless METRICS.include? metric
+          raise ArgumentError, "Invalid value: #{value.inspect}" unless VALUES.include? value
+
+          @metric = metric
+          @value = value
+        end
+
+        # @return [Symbol] The metric to compare, one of `:memory`, `:objects`, or `:strings`
+        attr_reader :metric
+
+        # @return [Symbol] The value to compare, one of `:allocated` or `:retained`
+        attr_reader :value
+
+        # Checks whether a {Comparator} equals another
+        #
+        # @param other [Benchmark::Memory::Comparator] The comparator to check against
+        #
+        # @return [Boolean]
+        def ==(other)
+          metric == other.metric && value == other.value
+        end
+
+        # Converts the {Comparator} to a Proc for passing to a block
+        #
+        # @return [Proc]
+        def to_proc
+          proc { |entry| entry.measurement.public_send(metric).public_send(value) }
+        end
+      end
+    end
+  end
+end

--- a/lib/benchmark/memory/report/comparison.rb
+++ b/lib/benchmark/memory/report/comparison.rb
@@ -5,15 +5,28 @@ module Benchmark
     class Report
       # Compare entries against each other.
       class Comparison
+        extend Forwardable
+
         # Instantiate a new comparison.
         #
         # @param entries [Array<Entry>] The entries to compare.
-        def initialize(entries)
-          @entries = entries.sort_by(&:measurement)
+        # @param comparator [Comparator] The comparator to use when generating.
+        def initialize(entries, comparator)
+          @entries = entries.sort_by(&comparator)
+          @comparator = comparator
         end
+
+        # @return [Comparator] The {Comparator} to use when generating the {Comparison}.
+        attr_reader :comparator
 
         # @return [Array<Entry>] The entries to compare.
         attr_reader :entries
+
+        # @!method metric
+        #   @return [Symbol] The metric to compare, one of `:memory`, `:objects`, or `:strings`
+        # @!method value
+        #   @return [Symbol] The value to compare, one of `:allocated` or `:retained`
+        def_delegators :@comparator, :metric, :value
 
         # Check if the comparison is possible
         #

--- a/lib/benchmark/memory/report/entry.rb
+++ b/lib/benchmark/memory/report/entry.rb
@@ -24,9 +24,10 @@ module Benchmark
 
         # Get the total amount of memory allocated in the entry.
         #
+        # @param comparison [Comparison] The {Comparison} to compare.
         # @return [Integer]
-        def allocated_memory
-          measurement.memory.allocated
+        def compared_metric(comparison)
+          measurement.public_send(comparison.metric).public_send(comparison.value)
         end
       end
     end

--- a/spec/benchmark/memory/job/io_output/comparison_formatter_spec.rb
+++ b/spec/benchmark/memory/job/io_output/comparison_formatter_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Benchmark::Memory::Job::IOOutput::ComparisonFormatter do
   end
 
   def comparison(entries)
-    Benchmark::Memory::Report::Comparison.new(entries)
+    Benchmark::Memory::Report::Comparison.new(entries, Benchmark::Memory::Report::Comparator.new)
   end
 
   def create_high_entry

--- a/spec/benchmark/memory/report/comparator_spec.rb
+++ b/spec/benchmark/memory/report/comparator_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Benchmark::Memory::Report::Comparator do
+  describe '.from_spec' do
+    it 'defaults to memory: :allocated when given nothing' do
+      subject = described_class.from_spec({})
+
+      expect(subject).to eq described_class.new(metric: :memory, value: :allocated)
+    end
+
+    it 'accepts all different types of metrics' do
+      memory = described_class.from_spec({ memory: :allocated })
+      expect(memory.metric).to eq :memory
+
+      objects = described_class.from_spec({ objects: :allocated })
+      expect(objects.metric).to eq :objects
+
+      strings = described_class.from_spec({ strings: :allocated })
+      expect(strings.metric).to eq :strings
+    end
+
+    it 'raises an error if given an invalid metric' do
+      expect { described_class.from_spec({ unknown: :allocated }) }
+        .to raise_error ArgumentError
+    end
+
+    it 'raises an error if given an invalid value' do
+      expect { described_class.from_spec({ memory: :unknown }) }
+        .to raise_error ArgumentError
+    end
+
+    it 'raises an error if given more than one metric' do
+      expect { described_class.from_spec({ memory: :allocated, objects: :retained }) }
+        .to raise_error ArgumentError
+    end
+  end
+end

--- a/spec/benchmark/memory/report/comparison_spec.rb
+++ b/spec/benchmark/memory/report/comparison_spec.rb
@@ -7,8 +7,9 @@ RSpec.describe Benchmark::Memory::Report::Comparison do
     it 'is sorted from smallest allocation to largest' do
       high_entry = create_high_entry
       low_entry = create_low_entry
+      comparator = Benchmark::Memory::Report::Comparator.from_spec({})
 
-      comparison = described_class.new([high_entry, low_entry])
+      comparison = described_class.new([high_entry, low_entry], comparator)
 
       expect(comparison.entries).to eq([low_entry, high_entry])
     end


### PR DESCRIPTION
Sometimes, you want to compare retained memory instead of allocated memory. This is useful when you want to check for a memory leak in different implementations of an algorithm. This change introduces the ability to compare the retained memory of your benchmarks.

This also includes a CI fix and a development harness fix. First, it ensures that Bundler is installed in the CI environment. Second, it checks the `Gemfile.lock` file into the repository to make it easier for CI and new contributors.