### PR TITLE
Allow comparison against a baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file. This projec
 
 [semver]: http://semver.org/spec/v2.0.0.html
 
+## [Unreleased](https://github.com/michaelherold/benchmark-memory/compare/v0.2.0...main)
+
+### Added
+
+- [#28](https://github.com/michaelherold/benchmark-memory/pull/28): Add the `order: :baseline` comparison method to compare results against a baseline report - [@michaelherold](https://github.com/michaelherold).
+
 ## [0.2.0](https://github.com/michaelherold/benchmark-memory/compare/v0.1.1...v0.2.0)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -113,6 +113,21 @@ end
 
 When you're looking for a memory leak, this configuration can help you because it compares your reports by the amount of memory that the garbage collector does not collect after the benchmark.
 
+#### Ordering by a baseline
+
+When you're looking to see whether you can improve memory performance by refactoring some code, it can help to visually compare your reports against a baseline. To do so, place your baseline report first and enable the `order: :baseline` option like so:
+
+```ruby
+Benchmark.memory do |bench|
+  bench.report("my baseline") {}
+  bench.report("another test") {}
+
+  bench.compare! order: :baseline
+end
+```
+
+This will always show the baseline at the top of the comparison and order the alternatives in ascending order against the baseline.
+
 ### Hold results between invocations
 
 ```ruby

--- a/lib/benchmark/memory/job/io_output/comparison_formatter.rb
+++ b/lib/benchmark/memory/job/io_output/comparison_formatter.rb
@@ -28,13 +28,13 @@ module Benchmark
             return '' unless comparison.possible?
 
             output = StringIO.new
-            best, *rest = comparison.entries
+            baseline, *rest = comparison.entries
             rest = Array(rest)
 
-            add_best_summary(best, output)
+            add_baseline_summary(baseline, output)
 
             rest.each do |entry|
-              add_comparison(entry, best, output)
+              add_comparison(entry, baseline, output)
             end
 
             output.string
@@ -42,21 +42,24 @@ module Benchmark
 
           private
 
-          def add_best_summary(best, output)
-            output << summary_message("%20s: %10i %s\n", best)
-          end
-
-          def add_comparison(entry, best, output)
-            output << summary_message('%20s: %10i %s - ', entry)
-            output << comparison_between(entry, best)
+          def add_baseline_summary(baseline, output)
+            output << summary_message('%20s: %10i %s', baseline)
             output << "\n"
           end
 
-          def comparison_between(entry, best)
-            ratio = entry.compared_metric(comparison).to_f / best.compared_metric(comparison)
+          def add_comparison(entry, baseline, output)
+            output << summary_message('%20s: %10i %s - ', entry)
+            output << comparison_between(entry, baseline)
+            output << "\n"
+          end
 
-            if ratio.abs > 1
-              format('%<ratio>.2fx more', ratio: ratio)
+          def comparison_between(entry, baseline)
+            ratio = entry.compared_metric(comparison).to_f / baseline.compared_metric(comparison)
+
+            if ratio > 1
+              format('%.2fx more', ratio)
+            elsif ratio < 1
+              format('%.2fx less', 1.0 / ratio)
             else
               'same'
             end

--- a/lib/benchmark/memory/report/comparison.rb
+++ b/lib/benchmark/memory/report/comparison.rb
@@ -12,7 +12,13 @@ module Benchmark
         # @param entries [Array<Entry>] The entries to compare.
         # @param comparator [Comparator] The comparator to use when generating.
         def initialize(entries, comparator)
-          @entries = entries.sort_by(&comparator)
+          @entries =
+            if comparator.baseline?
+              baseline = entries.shift
+              [baseline, *entries.sort_by(&comparator)]
+            else
+              entries.sort_by(&comparator)
+            end
           @comparator = comparator
         end
 
@@ -22,11 +28,15 @@ module Benchmark
         # @return [Array<Entry>] The entries to compare.
         attr_reader :entries
 
+        # @!method baseline?
+        #   @return [Boolean] Whether the comparison will print in baseline order.
         # @!method metric
         #   @return [Symbol] The metric to compare, one of `:memory`, `:objects`, or `:strings`
+        # @!method order
+        #   @return [Symbol] The order to report results, one of `:lowest`, or `:baseline`
         # @!method value
         #   @return [Symbol] The value to compare, one of `:allocated` or `:retained`
-        def_delegators :@comparator, :metric, :value
+        def_delegators :@comparator, :baseline?, :order, :metric, :value
 
         # Check if the comparison is possible
         #

--- a/spec/benchmark/memory/job/io_output/comparison_formatter_spec.rb
+++ b/spec/benchmark/memory/job/io_output/comparison_formatter_spec.rb
@@ -35,6 +35,18 @@ RSpec.describe Benchmark::Memory::Job::IOOutput::ComparisonFormatter do
 
       expect(formatter.to_s).to match(/same/)
     end
+
+    it 'does not output a comparison for the baseline' do
+      entries = [create_low_entry, create_high_entry]
+      comp = Benchmark::Memory::Report::Comparison.new(
+        entries,
+        Benchmark::Memory::Report::Comparator.new(order: :baseline)
+      )
+
+      formatter = described_class.new(comp)
+
+      expect(formatter.to_s).to match(/2500 allocated\n.*/).and(match(/10000 allocated - 4.00x more/))
+    end
   end
 
   def comparison(entries)

--- a/spec/benchmark/memory/report/comparison_spec.rb
+++ b/spec/benchmark/memory/report/comparison_spec.rb
@@ -13,6 +13,17 @@ RSpec.describe Benchmark::Memory::Report::Comparison do
 
       expect(comparison.entries).to eq([low_entry, high_entry])
     end
+
+    it 'sorts the baseline first when there is one' do
+      high_entry = create_high_entry
+      mid_entry = create_mid_entry
+      low_entry = create_low_entry
+      comparator = Benchmark::Memory::Report::Comparator.from_spec({ order: :baseline })
+
+      comparison = described_class.new([high_entry, mid_entry, low_entry], comparator)
+
+      expect(comparison.entries).to eq([high_entry, low_entry, mid_entry])
+    end
   end
 
   def create_high_entry
@@ -22,6 +33,13 @@ RSpec.describe Benchmark::Memory::Report::Comparison do
     )
   end
   alias_method :create_entry, :create_high_entry
+
+  def create_mid_entry
+    Benchmark::Memory::Report::Entry.new(
+      'mid',
+      create_measurement(5_000, 2_500)
+    )
+  end
 
   def create_low_entry
     Benchmark::Memory::Report::Entry.new(


### PR DESCRIPTION
This change introduces a new comparison ordering strategy where the initial report serves as the baseline against which the job compares the other reports.

This is useful in cases where you're testing out different implementations and want to see whether they are better or worse (and the comparative increase or decrease) in an easy-to-decipher order.

Closes #26